### PR TITLE
When reading an artifact, make sure that the list of inputs is a list of URIs

### DIFF
--- a/pond/metadata/dict.py
+++ b/pond/metadata/dict.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pond.metadata.metadata_source import MetadataSource
+from pond.metadata.metadata_source import MetadataSource, transform_metadata_value
 
 
 class DictMetadataSource(MetadataSource):
@@ -22,4 +22,4 @@ class DictMetadataSource(MetadataSource):
         return self.name
 
     def collect(self) -> dict[str, str]:
-        return {k: str(v) for k,v in self.metadata.items()}
+        return {k: transform_metadata_value(v) for k,v in self.metadata.items()}

--- a/pond/metadata/manifest.py
+++ b/pond/metadata/manifest.py
@@ -1,4 +1,5 @@
 from pond.metadata.dict import DictMetadataSource
+from pond.metadata.metadata_source import transform_metadata_value
 
 
 class Manifest:
@@ -65,6 +66,6 @@ class Manifest:
     def collect(self):
         dict_ = {}
         for name, source in self._sections.items():
-            source_metadata = {k: str(v) for k, v in source.collect().items()}
+            source_metadata = {k: transform_metadata_value(v) for k, v in source.collect().items()}
             dict_[name] = source_metadata
         return dict_

--- a/pond/metadata/metadata_source.py
+++ b/pond/metadata/metadata_source.py
@@ -1,6 +1,15 @@
 from abc import abstractmethod
 
 
+def transform_metadata_value(value):
+    """ Make sure that each value is either a list or a string. """
+    if isinstance(value, list):
+        transformed = [transform_metadata_value(el) for el in value]
+    else:
+        transformed = str(value)
+    return transformed
+
+
 class MetadataSource:
     """ Represents a source of metadata.
 

--- a/tests/metadata/test_dict.py
+++ b/tests/metadata/test_dict.py
@@ -6,5 +6,5 @@ def test_dict_metadata_source():
     source = DictMetadataSource(name='foo', metadata=metadata)
 
     assert source.section_name() == 'foo'
-    expected = {'a': '123', 'foo': '[1, 2, 3]'}
+    expected = {'a': '123', 'foo': ['1', '2', '3']}
     assert source.collect() == expected

--- a/tests/metadata/test_manifest.py
+++ b/tests/metadata/test_manifest.py
@@ -8,8 +8,10 @@ from pond.storage.file_datastore import FileDatastore
 def nested_metadata():
     user_metadata = {'a': '2', 'b': 'c'}
     sys_metadata = {'foo': 'bar'}
+    version_metadata = {'inputs': ['input1', 'input2']}
     dict_ = {
         'user': user_metadata,
+        'version': version_metadata,
         'sys': sys_metadata,
     }
     return dict_
@@ -29,4 +31,3 @@ def test_to_form_yaml(tmp_path, nested_metadata):
 
     reloaded = Manifest.from_yaml(manifest_location, datastore)
     assert reloaded.collect() == nested_metadata
-

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -13,10 +13,6 @@ from pond.storage.file_datastore import FileDatastore
 from pond.version_name import SimpleVersionName
 
 
-# test: inputs are saved as metadata
-# test: pond.write without giving class explicitly
-
-
 class MockArtifact(Artifact):
     @classmethod
     def _read_bytes(cls, file_, **kwargs):
@@ -171,7 +167,7 @@ def test_activity_metadata():
     assert metadata_source.name == 'activity'
     metadata = metadata_source.collect()
     assert metadata['author'] == author
-    assert metadata['inputs'] == str(inputs)
+    assert metadata['inputs'] == inputs
     assert metadata['source'] == source
 
 
@@ -189,9 +185,7 @@ def test_write_inputs_to_metadata(activity):
 
     expected_inputs = ['pond://foostore/test_location/bah/v2',
                        'pond://foostore/test_location/meh/v1']
-    # TODO activity manifest should parse inputs list
-    #assert activity_metadata['inputs'] == expected_inputs
-    assert activity_metadata['inputs'] == str(expected_inputs)
+    assert activity_metadata['inputs'] == expected_inputs
 
 
 def test_write_mode_error_if_exists(activity):


### PR DESCRIPTION
Previously, it was a string containing a list of URIs

Fix #9