### PR TITLE
Matplotlib figure creates a PNG artifact

### DIFF
--- a/pond/artifact/pil_image_artifact.py
+++ b/pond/artifact/pil_image_artifact.py
@@ -6,9 +6,39 @@ from pond.artifact import Artifact
 from pond.artifact.artifact_registry import global_artifact_registry
 
 
+def _image_from_matplotlib_fig(fig):
+    """ Transform a Matplotlib Figure in a PIL RGB Image object"""
+    fig.canvas.draw()
+    image = Image.frombytes(
+        'RGB',
+        fig.canvas.get_width_height(),
+        fig.canvas.tostring_rgb()
+    )
+    return image
+
+
 class PILImageArtifact(Artifact):
     """ Artifact for Matlab figures.
     """
+
+    def __init__(self, data, metadata=None, data_hash=None):
+        """ Create an Artifact.
+
+        Parameters
+        ----------
+        data: Figure
+            A Matplotlib Figure object. It is going to be transformed in a PNG figure.
+        metadata: dict
+            User-defined metadata, saved with the artifact (optional).
+            The metadata keys and values will be stored as strings.
+        data_hash: str
+            The data hash of the data, if known (for example, when the artifact
+            is read from a Version). If None, the hash is re-computed.
+        """
+        # Transform the matplotlib figure in a PNG image.
+        if isinstance(data, Figure):
+            data = _image_from_matplotlib_fig(data)
+        super().__init__(data, metadata, data_hash=data_hash)
 
     # --- Artifact class interface
 
@@ -24,18 +54,6 @@ class PILImageArtifact(Artifact):
     def filename(basename):
         return basename + '.png'
 
-    # --- PILImageArtifact class interface
-
-    @classmethod
-    def from_matplotlib_fig(cls, fig, metadata=None):
-        fig.canvas.draw()
-        image = Image.frombytes(
-            'RGB',
-            fig.canvas.get_width_height(),
-            fig.canvas.tostring_rgb()
-        )
-        return cls(image, metadata)
-
     # --- Artifact interface
 
     def write_bytes(self, file_, **kwargs):
@@ -46,27 +64,6 @@ class PILImageArtifact(Artifact):
         self.data.save(file_, pnginfo=png_metadata)
 
 
-class MatplotlibFigureArtifact(Artifact):
-
-    # --- Artifact class interface
-
-    # TODO: this can't return another class
-    @classmethod
-    def _read_bytes(cls, file_, **kwargs):
-        """ Read a Matlab figure artifact from CSV file. """
-        image = Image.open(file_).copy()
-        metadata = image.info
-        return PILImageArtifact(image, metadata)
-
-    @staticmethod
-    def filename(basename):
-        return basename + '.png'
-
-    def write_bytes(self, file_, **kwargs):
-        pil = PILImageArtifact.from_matplotlib_fig(self.data, self.metadata)
-        pil.write_bytes(file_, **kwargs)
-
-
 global_artifact_registry.register(artifact_class=PILImageArtifact, data_class=Image, format='png')
-global_artifact_registry.register(artifact_class=MatplotlibFigureArtifact, data_class=Figure,
+global_artifact_registry.register(artifact_class=PILImageArtifact, data_class=Figure,
                                   format='png')

--- a/pond/artifact/pil_image_artifact.py
+++ b/pond/artifact/pil_image_artifact.py
@@ -26,8 +26,9 @@ class PILImageArtifact(Artifact):
 
         Parameters
         ----------
-        data: Figure
-            A Matplotlib Figure object. It is going to be transformed in a PNG figure.
+        data: Image | Figure
+            A PIL Image or Matplotlib Figure object.
+            A Matplotlib Figure is going to be transformed in an Image.
         metadata: dict
             User-defined metadata, saved with the artifact (optional).
             The metadata keys and values will be stored as strings.

--- a/tests/artifact/test_pil_image_artifact.py
+++ b/tests/artifact/test_pil_image_artifact.py
@@ -3,7 +3,9 @@ import numpy as np
 from PIL.Image import Image
 import pytest
 
-from pond.artifact.pil_image_artifact import PILImageArtifact
+from pond.activity import Activity
+from pond.artifact.pil_image_artifact import PILImageArtifact, _image_from_matplotlib_fig
+from pond.storage.file_datastore import FileDatastore
 
 
 @pytest.fixture
@@ -25,15 +27,14 @@ def metadata():
     return metadata
 
 
-def test_from_matplotlib_fig(fig, metadata):
-    artifact = PILImageArtifact.from_matplotlib_fig(fig, metadata)
-
-    assert artifact.metadata == metadata
-    assert isinstance(artifact.data, Image)
+def test_from_matplotlib_fig(fig):
+    data = _image_from_matplotlib_fig(fig)
+    assert isinstance(data, Image)
 
 
 def test_write_read_bytes(tmp_path, fig, metadata):
-    original = PILImageArtifact.from_matplotlib_fig(fig, metadata)
+    data = _image_from_matplotlib_fig(fig)
+    original = PILImageArtifact(data, metadata=metadata)
 
     with open(tmp_path / 'test.png', 'wb') as f:
         original.write_bytes(f)
@@ -44,3 +45,15 @@ def test_write_read_bytes(tmp_path, fig, metadata):
     assert reloaded.metadata == {k: str(v) for k, v in metadata.items()}
     assert isinstance(reloaded.data, Image)
     assert reloaded.data.size == fig.canvas.get_width_height()
+
+
+def test_write_read_matplotlib_figure(tmp_path, fig):
+    activity = Activity(
+        source='test_pond.py',
+        datastore=FileDatastore(id='foostore', base_path=tmp_path),
+        location='test_location',
+    )
+
+    activity.write(fig, 'matplotlib_figure')
+    artifact = activity.read_artifact('matplotlib_figure')
+    assert isinstance(artifact, PILImageArtifact)


### PR DESCRIPTION
There was a strong smell in the code: the MatplotlibFigureArtifact class was actually building a PILImageArtifact. Not only it was weird, it didn't work properly.

I solved it by having the PILImageArtifact being able to handle Matplotlib Figures.