### PR TITLE
Specifying the datastore as a string creates a FileDatastore with that path

### DIFF
--- a/notebook/demo_basics/010_initial_data.ipynb
+++ b/notebook/demo_basics/010_initial_data.ipynb
@@ -30,15 +30,11 @@
     "from pond.storage.file_datastore import FileDatastore\n",
     "from pond import Activity\n",
     "\n",
-    "# We create a datastore in a local directory called `catalog`\n",
-    "# The directory needs to exist already\n",
-    "datastore = FileDatastore(id='local_demo', base_path='./catalog')\n",
-    "\n",
     "# The activity object is usually the only object you need to care about.\n",
     "# It is used to read and write artifacts to the datastore, and it takes care of all the versioning and lineage tracking for you.\n",
     "activity = Activity(\n",
     "    source='010_initial_data.ipynb',  # This \"source\" will be used as the lineage for the artifacts that you write in this session\n",
-    "    datastore=datastore, \n",
+    "    datastore='./catalog',    # We use a filesystem datastore in a local directory called `catalog` (the directory needs to exist already)\n",
     "    location='experiment1',   # Within the datastore, you can specify a default location (optional). It can be used to organize different \n",
     "    author='pietro',          # The author is also used in the lineage metadata\n",
     ")"
@@ -250,7 +246,7 @@
     {
      "data": {
       "text/plain": [
-       "<pond.version.Version at 0x12a7cf5d0>"
+       "<pond.version.Version at 0x138edb310>"
       ]
      },
      "execution_count": 5,
@@ -328,15 +324,15 @@
    "outputs": [
     {
      "ename": "VersionAlreadyExists",
-     "evalue": "Version already exists:  pond://local_demo/experiment1/condition1_results/v1.",
+     "evalue": "Version already exists:  pond://catalog/experiment1/condition1_results/v1.",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mVersionAlreadyExists\u001b[0m                      Traceback (most recent call last)",
       "Cell \u001b[0;32mIn[9], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# If we try to write over an older versions, we get a loud complaint\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m version \u001b[38;5;241m=\u001b[39m \u001b[43mactivity\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mwrite\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcondition1\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mcondition1_results\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mversion_name\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mv1\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/o/pond/pond/activity.py:302\u001b[0m, in \u001b[0;36mActivity.write\u001b[0;34m(self, data, name, version_name, metadata, write_mode, location, artifact_class, format)\u001b[0m\n\u001b[1;32m    300\u001b[0m activity_metadata_source \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_metadata()\n\u001b[1;32m    301\u001b[0m manifest\u001b[38;5;241m.\u001b[39madd_section(activity_metadata_source)\n\u001b[0;32m--> 302\u001b[0m version \u001b[38;5;241m=\u001b[39m \u001b[43mversioned_artifact\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mwrite\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    303\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdata\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdata\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    304\u001b[0m \u001b[43m    \u001b[49m\u001b[43mmanifest\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmanifest\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    305\u001b[0m \u001b[43m    \u001b[49m\u001b[43mversion_name\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mversion_name\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    306\u001b[0m \u001b[43m    \u001b[49m\u001b[43mwrite_mode\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mwrite_mode\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    307\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    309\u001b[0m version_uri \u001b[38;5;241m=\u001b[39m version\u001b[38;5;241m.\u001b[39mget_uri(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlocation, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdatastore)\n\u001b[1;32m    310\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mwrite_history\u001b[38;5;241m.\u001b[39madd(version_uri)\n",
+      "File \u001b[0;32m~/o/pond/pond/activity.py:313\u001b[0m, in \u001b[0;36mActivity.write\u001b[0;34m(self, data, name, version_name, metadata, write_mode, location, artifact_class, format)\u001b[0m\n\u001b[1;32m    311\u001b[0m activity_metadata_source \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_metadata()\n\u001b[1;32m    312\u001b[0m manifest\u001b[38;5;241m.\u001b[39madd_section(activity_metadata_source)\n\u001b[0;32m--> 313\u001b[0m version \u001b[38;5;241m=\u001b[39m \u001b[43mversioned_artifact\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mwrite\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    314\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdata\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdata\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    315\u001b[0m \u001b[43m    \u001b[49m\u001b[43mmanifest\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmanifest\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    316\u001b[0m \u001b[43m    \u001b[49m\u001b[43mversion_name\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mversion_name\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    317\u001b[0m \u001b[43m    \u001b[49m\u001b[43mwrite_mode\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mwrite_mode\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    318\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    320\u001b[0m version_uri \u001b[38;5;241m=\u001b[39m version\u001b[38;5;241m.\u001b[39mget_uri(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlocation, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdatastore)\n\u001b[1;32m    321\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mwrite_history\u001b[38;5;241m.\u001b[39madd(version_uri)\n",
       "File \u001b[0;32m~/o/pond/pond/versioned_artifact.py:225\u001b[0m, in \u001b[0;36mVersionedArtifact.write\u001b[0;34m(self, data, manifest, version_name, write_mode)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m write_mode \u001b[38;5;241m==\u001b[39m WriteMode\u001b[38;5;241m.\u001b[39mERROR_IF_EXISTS:\n\u001b[1;32m    224\u001b[0m     uri \u001b[38;5;241m=\u001b[39m version\u001b[38;5;241m.\u001b[39mget_uri(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlocation, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdatastore)\n\u001b[0;32m--> 225\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m VersionAlreadyExists(uri)\n\u001b[1;32m    226\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    227\u001b[0m     uri \u001b[38;5;241m=\u001b[39m version\u001b[38;5;241m.\u001b[39mget_uri(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlocation, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdatastore)\n",
-      "\u001b[0;31mVersionAlreadyExists\u001b[0m: Version already exists:  pond://local_demo/experiment1/condition1_results/v1."
+      "\u001b[0;31mVersionAlreadyExists\u001b[0m: Version already exists:  pond://catalog/experiment1/condition1_results/v1."
      ]
     }
    ],
@@ -421,16 +417,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<pond.version.Version at 0x12b0aa690>"
+       "<pond.version.Version at 0x139005390>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -453,7 +449,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -462,7 +458,7 @@
        "set()"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -473,19 +469,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'pond://local_demo/experiment1/condition1_results/v1',\n",
-       " 'pond://local_demo/experiment1/condition1_results/v2',\n",
-       " 'pond://local_demo/experiment1/condition1_results/v3',\n",
-       " 'pond://local_demo/experiment1/condition2_results/v1'}"
+       "{'pond://catalog/experiment1/condition1_results/v1',\n",
+       " 'pond://catalog/experiment1/condition1_results/v2',\n",
+       " 'pond://catalog/experiment1/condition1_results/v3',\n",
+       " 'pond://catalog/experiment1/condition2_results/v1'}"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebook/demo_basics/020_create_plot.ipynb
+++ b/notebook/demo_basics/020_create_plot.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T14:53:07.218064Z",
@@ -38,7 +38,7 @@
     "# As usual, we create an Activity object at the start of our notebook or script\n",
     "activity = Activity(\n",
     "    source='020_create_plot.ipynb', \n",
-    "    datastore=FileDatastore(id='local_demo', base_path='./catalog'),\n",
+    "    datastore='./catalog',\n",
     "    location='experiment1',\n",
     "    author='pietro', \n",
     ")"
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T14:53:07.385252Z",
@@ -74,17 +74,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'pond://local_demo/experiment1/condition1_results/v3',\n",
-       " 'pond://local_demo/experiment1/condition2_results/v1'}"
+       "{'pond://catalog/experiment1/condition1_results/v3',\n",
+       " 'pond://catalog/experiment1/condition2_results/v1'}"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T14:53:07.528141Z",
@@ -170,7 +170,7 @@
        "9           3"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T14:53:07.976754Z",
@@ -256,7 +256,7 @@
        "8          -3"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -276,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T14:46:29.913386Z",
@@ -294,10 +294,10 @@
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x12da8c490>]"
+       "[<matplotlib.lines.Line2D at 0x12fb0eb90>]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -329,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false,
     "jupyter": {
@@ -352,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 8,
    "metadata": {
     "scrolled": true
    },
@@ -363,16 +363,16 @@
        "{'user': {'extra_info': 'Some extra information for illustration'},\n",
        " 'activity': {'source': '020_create_plot.ipynb',\n",
        "  'author': 'pietro',\n",
-       "  'inputs': ['pond://local_demo/experiment1/condition1_results/v3',\n",
-       "   'pond://local_demo/experiment1/condition2_results/v1']},\n",
-       " 'version': {'uri': 'pond://local_demo/experiment1/analysis/analysis/v1',\n",
+       "  'inputs': ['pond://catalog/experiment1/condition1_results/v3',\n",
+       "   'pond://catalog/experiment1/condition2_results/v1']},\n",
+       " 'version': {'uri': 'pond://catalog/experiment1/analysis/analysis/v1',\n",
        "  'filename': 'analysis_v1.png',\n",
-       "  'date_time': '2024-09-11 13:57:00.950656',\n",
+       "  'date_time': '2024-09-12 11:22:12.069070',\n",
        "  'artifact_name': 'analysis'},\n",
        " 'artifact': {'data_hash': '02f36ddfff9d1b39a747204ff790375a'}}"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -390,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -400,7 +400,7 @@
        "<PIL.Image.Image image mode=RGB size=640x480>"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -409,13 +409,6 @@
     "# By default, we load the latest version\n",
     "activity.read('analysis')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",

--- a/notebook/demo_basics/030_modify_data.ipynb
+++ b/notebook/demo_basics/030_modify_data.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T12:28:07.579223Z",
@@ -31,8 +31,7 @@
     "from pond import Activity\n",
     "\n",
     "\n",
-    "datastore = FileDatastore(id='local_demo', base_path='./catalog')\n",
-    "activity = Activity(source='030_modify_data.ipynb', author='pietro', datastore=datastore, location='experiment1')\n"
+    "activity = Activity(source='030_modify_data.ipynb', author='pietro', datastore='./catalog', location='experiment1')\n"
    ]
   },
   {
@@ -46,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T12:29:03.835412Z",
@@ -68,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T12:30:08.393916Z",
@@ -83,10 +82,10 @@
     {
      "data": {
       "text/plain": [
-       "<pond.version.Version at 0x1272db090>"
+       "<pond.version.Version at 0x1301042d0>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -113,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false,
     "jupyter": {
@@ -153,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -173,7 +172,7 @@
        " 'pond://local_demo/experiment1/condition2_results/v2'}"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -194,16 +193,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x136bf27d0>]"
+       "[<matplotlib.lines.Line2D at 0x130510a50>]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -236,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -258,12 +257,12 @@
        "   'pond://local_demo/experiment1/condition2_results/v2']},\n",
        " 'version': {'uri': 'pond://local_demo/experiment1/analysis/analysis/v2',\n",
        "  'filename': 'analysis_v2.png',\n",
-       "  'date_time': '2024-09-11 14:11:04.734867',\n",
+       "  'date_time': '2024-09-12 11:22:36.097994',\n",
        "  'artifact_name': 'analysis'},\n",
        " 'artifact': {'data_hash': '87af9da5a06b714c902eeecf0963e0cf'}}"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -282,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -294,12 +293,12 @@
        " 'artifact': {'data_hash': '3e999b12fe253ecdd5b9fcaaf9002888'},\n",
        " 'user': {'validated': 'True'},\n",
        " 'version': {'artifact_name': 'condition2_results',\n",
-       "  'date_time': '2024-09-11 13:58:51.854239',\n",
+       "  'date_time': '2024-09-12 11:22:33.143955',\n",
        "  'filename': 'condition2_results_v2.csv',\n",
-       "  'uri': 'pond://local_demo/experiment1/condition2_results/condition2_results/v2'}}"
+       "  'uri': 'pond://catalog/experiment1/condition2_results/condition2_results/v2'}}"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -320,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -330,7 +329,7 @@
        "<PIL.Image.Image image mode=RGB size=640x480>"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -341,25 +340,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'activity': {'author': 'pietro',\n",
-       "  'inputs': ['pond://local_demo/experiment1/condition1_results/v3',\n",
-       "   'pond://local_demo/experiment1/condition2_results/v1'],\n",
+       "  'inputs': ['pond://catalog/experiment1/condition1_results/v3',\n",
+       "   'pond://catalog/experiment1/condition2_results/v1'],\n",
        "  'source': '020_create_plot.ipynb'},\n",
        " 'artifact': {'data_hash': '02f36ddfff9d1b39a747204ff790375a'},\n",
        " 'user': {'extra_info': 'Some extra information for illustration'},\n",
        " 'version': {'artifact_name': 'analysis',\n",
-       "  'date_time': '2024-09-11 13:57:00.950656',\n",
+       "  'date_time': '2024-09-12 11:22:12.069070',\n",
        "  'filename': 'analysis_v1.png',\n",
-       "  'uri': 'pond://local_demo/experiment1/analysis/analysis/v1'}}"
+       "  'uri': 'pond://catalog/experiment1/analysis/analysis/v1'}}"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,3 +1,4 @@
+import os.path
 from unittest.mock import ANY, Mock
 
 import pytest
@@ -379,3 +380,16 @@ def test_location_can_be_overwritten(tmp_path):
     manifest = activity.read_manifest('meh', location='other_location')
     assert (manifest.collect_section('version')['uri'] ==
             'pond://foostore/other_location/meh/meh/v1')
+
+
+def test_datastore_string_creates_filedatastore(tmp_path):
+    path = str(tmp_path)
+    activity = Activity(
+        source='test_pond.py',
+        datastore=path,
+        location='test_location',
+    )
+    assert isinstance(activity.datastore, FileDatastore)
+    assert activity.datastore.base_path == path
+    expected_id = os.path.split(path)[-1]
+    assert activity.datastore.id == expected_id


### PR DESCRIPTION
Fix #14 

Simplifies the basic workflow: instead of creating a `FileDatastore` and passing it to the `Activity` object, one is created automatically id the user passes a string.