### PR TITLE
Make the read/write methods of dict and image artifacts stricter

### DIFF
--- a/pond/activity.py
+++ b/pond/activity.py
@@ -101,7 +101,8 @@ class Activity:
             Location in the data store where artifacts are read. If None, the default location
             specified in the constructor is used.
         kwargs: dict
-            Parameters for the artifact reader.
+            Optional parameters that are passed to the artifact reader. Refer to the documentation
+            of the artifact classes for more information.
 
         Return
         ------
@@ -192,7 +193,8 @@ class Activity:
             Location in the data store where artifacts are read. If None, the default location
             specified in the constructor is used.
         kwargs: dict
-            Parameters for the artifact reader.
+            Optional parameters that are passed to the artifact reader. Refer to the documentation
+            of the artifact classes for more information.
 
         Return
         ------
@@ -229,7 +231,8 @@ class Activity:
             Location in the data store where artifacts are read. If None, the default location
             specified in the constructor is used.
         kwargs: dict
-            Parameters for the artifact reader.
+            Optional parameters that are passed to the artifact reader. Refer to the documentation
+            of the artifact classes for more information.
 
         Return
         ------

--- a/pond/artifact/artifact.py
+++ b/pond/artifact/artifact.py
@@ -93,7 +93,8 @@ class Artifact(ABC):
             The data hash of the data, if known (for example, when the artifact
             is read from a Version). If None, the hash is re-computed.
         kwargs: dict
-            Parameters for the reader.
+            Optional parameters for the reader.
+            Refer to the documentation of the artifact classes for more information.
 
         Returns
         -------
@@ -119,7 +120,8 @@ class Artifact(ABC):
         file_: file-like object
             A file-like object to which the artifact is written, opened in binary mode.
         kwargs: dict
-            Parameters for the writer.
+            Optional parameters for the writer.
+            Refer to the documentation of the artifact classes for more information.
 
         """
         pass
@@ -144,7 +146,8 @@ class Artifact(ABC):
             The data hash of the data, if known (for example, when the artifact
             is read from a Version). If None, the hash is re-computed.
         kwargs: dict
-            Parameters for the reader.
+            Optional parameters for the reader.
+            Refer to the documentation of the artifact classes for more information.
 
         Returns
         -------
@@ -157,7 +160,6 @@ class Artifact(ABC):
 
         return cls(data, metadata=metadata, data_hash=data_hash)
 
-    # todo why the kwargs
     def write(self, path, **kwargs):
         """ Writes the artifact to file.
 
@@ -166,7 +168,8 @@ class Artifact(ABC):
         path: str
             Path to which the artifact is written.
         kwargs: dict
-            Parameters for the writer.
+            Optional parameters for the writer.
+            Refer to the documentation of the artifact classes for more information.
 
         """
         with open(path, 'wb') as f:

--- a/pond/artifact/dict_artifact.py
+++ b/pond/artifact/dict_artifact.py
@@ -16,13 +16,13 @@ class DictArtifact(Artifact):
         return basename + '.json'
 
     @classmethod
-    def _read_bytes(cls, file_, **kwargs):
+    def _read_bytes(cls, file_):
         txt = file_.read().decode()
         data = json.loads(txt)
         metadata = data.pop('__metadata__', dict())
         return data, metadata
 
-    def write_bytes(self, file_, **kwargs):
+    def write_bytes(self, file_):
         dict_ = dict(self.data)
         dict_['__metadata__'] = {str(k): str(v) for k, v in self.metadata.items()}
         txt = json.dumps(dict_)

--- a/pond/artifact/pil_image_artifact.py
+++ b/pond/artifact/pil_image_artifact.py
@@ -44,7 +44,7 @@ class PILImageArtifact(Artifact):
     # --- Artifact class interface
 
     @classmethod
-    def _read_bytes(cls, file_, **kwargs):
+    def _read_bytes(cls, file_):
         """ Read a Matlab figure artifact from CSV file. """
         # todo "copy" is because opening the file is lazy; is there a better way?
         image = Image.open(file_).copy()
@@ -57,7 +57,7 @@ class PILImageArtifact(Artifact):
 
     # --- Artifact interface
 
-    def write_bytes(self, file_, **kwargs):
+    def write_bytes(self, file_):
         png_metadata = PngInfo()
         for key, value in self.metadata.items():
             png_metadata.add_text(key, str(value))
@@ -66,5 +66,4 @@ class PILImageArtifact(Artifact):
 
 
 global_artifact_registry.register(artifact_class=PILImageArtifact, data_class=Image, format='png')
-global_artifact_registry.register(artifact_class=PILImageArtifact, data_class=Figure,
-                                  format='png')
+global_artifact_registry.register(artifact_class=PILImageArtifact, data_class=Figure, format='png')


### PR DESCRIPTION
Do not allow passing random keyword arguments that end up being ignored.